### PR TITLE
fix(datapoints-graph):  provide context do datapoints selector

### DIFF
--- a/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.html
+++ b/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.html
@@ -81,6 +81,7 @@
       <c8y-datapoint-selection-list
         [minActiveCount]="1"
         [defaultFormOptions]="datapointSelectDefaultFormOptions"
+        [config]="datapointSelectionConfig"
         formControlName="datapoints"
         name="datapoints"
       ></c8y-datapoint-selection-list>

--- a/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.spec.ts
+++ b/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.spec.ts
@@ -24,11 +24,13 @@ import { DatapointSelectorModule } from '@c8y/ngx-components/datapoint-selector'
 import { aggregationType } from '@c8y/client';
 import { AnimationBuilder } from '@angular/animations';
 import { take } from 'rxjs/operators';
+import { ActivatedRoute } from '@angular/router';
 
 describe('DatapointsGraphWidgetConfigComponent', () => {
   let component: DatapointsGraphWidgetConfigComponent;
   let fixture: ComponentFixture<DatapointsGraphWidgetConfigComponent>;
   let ngForm: NgForm;
+  const mockContextData = { id: '1234' };
   const originalResizeObserver = window.ResizeObserver;
   const dateFrom = new Date('2023-03-19T11:00:19.710Z');
   const dateTo = new Date('2023-03-20T11:00:19.710Z');
@@ -73,6 +75,16 @@ describe('DatapointsGraphWidgetConfigComponent', () => {
         { provide: window, useValue: { ResizeObserver: {} } },
         NgForm,
         { provide: AnimationBuilder, useValue: { build: () => null } },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            root: {
+              firstChild: {
+                snapshot: { data: { contextData: mockContextData } },
+              },
+            },
+          },
+        },
       ],
     });
     await TestBed.compileComponents();
@@ -90,6 +102,15 @@ describe('DatapointsGraphWidgetConfigComponent', () => {
   });
 
   describe('ngOnInit', () => {
+    it('should set contextAsset for datapoint selector', () => {
+      // when
+      component.ngOnInit();
+      // then
+      expect(component.datapointSelectionConfig.contextAsset).toEqual(
+        mockContextData
+      );
+    });
+
     it('should initialize form', () => {
       // given
       jest.spyOn(component, 'timePropsChanged');

--- a/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.ts
+++ b/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.ts
@@ -26,7 +26,11 @@ import {
 import { TranslateService } from '@ngx-translate/core';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
-import { DatapointAttributesFormConfig } from '@c8y/ngx-components/datapoint-selector';
+import {
+  DatapointAttributesFormConfig,
+  DatapointSelectorModalOptions,
+} from '@c8y/ngx-components/datapoint-selector';
+import { WidgetConfigComponent } from '@c8y/ngx-components/context-dashboard';
 
 @Component({
   selector: 'c8y-datapoints-graph-widget-config',
@@ -64,16 +68,21 @@ export class DatapointsGraphWidgetConfigComponent
     showRange: true,
     showChart: true,
   };
+  datapointSelectionConfig: Partial<DatapointSelectorModalOptions> = {};
   activeDatapointsExists: boolean;
   private destroy$ = new Subject<void>();
 
   constructor(
     private formBuilder: FormBuilder,
     private form: NgForm,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private widgetConfig: WidgetConfigComponent
   ) {}
 
   ngOnInit() {
+    if (this.widgetConfig.context?.id) {
+      this.datapointSelectionConfig.contextAsset = this.widgetConfig?.context;
+    }
     this.initForm();
     this.initDateSelection();
     this.setActiveDatapointsExists();

--- a/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.ts
+++ b/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.ts
@@ -30,7 +30,7 @@ import {
   DatapointAttributesFormConfig,
   DatapointSelectorModalOptions,
 } from '@c8y/ngx-components/datapoint-selector';
-import { WidgetConfigComponent } from '@c8y/ngx-components/context-dashboard';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'c8y-datapoints-graph-widget-config',
@@ -76,12 +76,13 @@ export class DatapointsGraphWidgetConfigComponent
     private formBuilder: FormBuilder,
     private form: NgForm,
     private translate: TranslateService,
-    private widgetConfig: WidgetConfigComponent
+    private route: ActivatedRoute
   ) {}
 
   ngOnInit() {
-    if (this.widgetConfig.context?.id) {
-      this.datapointSelectionConfig.contextAsset = this.widgetConfig?.context;
+    const context = this.route.root.firstChild.snapshot.data?.contextData;
+    if (context?.id) {
+      this.datapointSelectionConfig.contextAsset = context;
     }
     this.initForm();
     this.initDateSelection();


### PR DESCRIPTION
when datapoint graph widget 2.0 is added to group dashboard, it should show only this group assets in datapoints selector. 

n/a

## Proposed changes
Right now, when Datapoints graph 2.0 is added to group dashboard, all the assets are available in datapoints selector. Only this group assets should be available. All possible assets should be visible when widget is added to Cockpit dashboard. Proper behavior is implemented in KPI Widget.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `cumulocity-community-plugins`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://cumulocity.atlassian.net/browse/MTM-53309
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/SoftwareAG/cumulocity-community-plugins/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/SoftwareAG/cumulocity-community-plugins/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
To fully test this bug fix, plugin should be build, uploaded to tenant and installed to cockpit. Then, two scenarios should be handled:
1. add data points graph 2.0 to cockpit home dashboard -> Add datapoint -> user should be able to select from all possible devices
2. add data points graph 2.0 to cockpit group dashboard (group should contain at least one device) -> Add datapoint -> user should be able to select only from this group assets
<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
