### PR TITLE
fix(datapoints-graph): adding padding to the datapoint graph config view

### DIFF
--- a/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.html
+++ b/src/datapoints-graph/datapoints-graph-config/datapoints-graph-widget-config.component.html
@@ -1,5 +1,5 @@
 <div class="row no-card-context d-flex">
-  <div class="col-md-5 bg-level-1 conf-col inner-scroll">
+  <div class="col-md-5 bg-level-1 conf-col inner-scroll p-t-8 p-l-24">
     <div class="form-group m-b-16">
       <label translate class="d-inline-block">Date selection</label>
       <button
@@ -87,7 +87,7 @@
     </form>
   </div>
 
-  <div class="col-md-7 sticky-top">
+  <div class="col-md-7 sticky-top p-t-8 p-r-24">
     <label>{{ 'Options' | translate }}</label>
     <c8y-time-controls
       *ngIf="!config?.widgetInstanceGlobalTimeContext"
@@ -100,7 +100,7 @@
       [config]="config"
       [alerts]="alerts"
       class="d-block p-relative overflow-hidden"
-      style="--chart-spacer: 0px; height: calc(100vh - 460px)"
+      style="--chart-spacer: 0px; height: calc(100vh - 500px)"
       (timeRangeChangeOnRealtime)="updateTimeRangeOnRealtime($event)"
     ></c8y-charts>
 


### PR DESCRIPTION
## Proposed changes
Padding is missing in 10.17 upwards (new design) in the configuration view. It looks broken:
![MicrosoftTeams-image (8)](https://github.com/SoftwareAG/cumulocity-community-plugins/assets/3398624/853ff722-4abf-4508-9c2b-fd39eebcdfbb)


## Types of changes
Added some padding. Looks correct in 10.17+ but adds some extra padding to 10.16 which I guess is fine:
![image](https://github.com/SoftwareAG/cumulocity-community-plugins/assets/3398624/6b23ce82-d457-4080-85d0-6e30fa14d477)


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
no issue

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/SoftwareAG/cumulocity-community-plugins/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/SoftwareAG/cumulocity-community-plugins/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
